### PR TITLE
Use `getAuthRoutes` instead of `getAuthRouter`

### DIFF
--- a/src/routes/index.js
+++ b/src/routes/index.js
@@ -1,10 +1,10 @@
 import express from 'express'
-import getAuthRouter from './auth'
+import getAuthRoutes from './auth'
 import getListItemsRoutes from './list-items'
 
 function getRouter() {
   const router = express.Router()
-  router.use('/auth', getAuthRouter())
+  router.use('/auth', getAuthRoutes())
   router.use('/list-items', getListItemsRoutes())
   return router
 }


### PR DESCRIPTION
I might be reading this wrong, but it seems to me there is a typo since `getAuthRouter` doesn't exist anywhere on the repo.