### PR TITLE
fixed all faker deprecated methods

### DIFF
--- a/src/db/utils.js
+++ b/src/db/utils.js
@@ -1,3 +1,3 @@
 import faker from 'faker'
 
-export const generateUUID = () => faker.random.uuid()
+export const generateUUID = () => faker.datatype.uuid()

--- a/test/utils/generate.js
+++ b/test/utils/generate.js
@@ -5,7 +5,7 @@ import {getUserToken, getSaltAndHash} from '../../src/utils/auth'
 // prefex all of the ones we generate with `!0_Oo` to ensure it's valid.
 const getPassword = (...args) => `!0_Oo${faker.internet.password(...args)}`
 const getUsername = faker.internet.userName
-const getId = faker.random.uuid
+const getId = faker.datatype.uuid
 const getSynopsis = faker.lorem.paragraph
 const getNotes = faker.lorem.paragraph
 
@@ -24,7 +24,7 @@ function buildBook(overrides) {
     title: faker.lorem.words(),
     author: faker.name.findName(),
     coverImageUrl: faker.image.imageUrl(),
-    pageCount: faker.random.number(400),
+    pageCount: faker.datatype.number(400),
     publisher: faker.company.companyName(),
     synopsis: faker.lorem.paragraph(),
     ...overrides,
@@ -42,8 +42,8 @@ function buildListItem(overrides = {}) {
     id: getId(),
     bookId,
     ownerId: owner.id,
-    rating: faker.random.number(5),
-    notes: faker.random.boolean() ? '' : getNotes(),
+    rating: faker.datatype.number(5),
+    notes: faker.datatype.boolean() ? '' : getNotes(),
     finishDate,
     startDate,
     ...overrides,


### PR DESCRIPTION
There are so annoying while running the test and faker warn about deprecated methods, for instance,

![Screen Shot 2021-12-07 at 11 54 42 AM](https://user-images.githubusercontent.com/6449655/144969486-e62dcfbf-1077-43be-ad91-01f4a1878e8d.png)

This commit tend to fixed all faker deprecated methods

- faker.random.number -->
faker.datatype.number
- faker.random.boolean --> faker.datatype.boolean
- faker.random.uuid --> faker.datatype.uuid